### PR TITLE
objparams['form_name'] 

### DIFF
--- a/classes/basic/class.rex_xform.inc.php
+++ b/classes/basic/class.rex_xform.inc.php
@@ -168,6 +168,20 @@ class rex_xform
   function getForm() {
 
     global $REX;
+    
+// *************************************************** Quick & Dirty Hack - Start
+$elements = $this->objparams["form_elements"];
+
+foreach ($elements as $e)
+{
+ if($e[0] == 'objparams' && $e[1] == 'form_name' && trim($e[2]) != '')
+ {
+   $this->objparams["form_name"] = trim($e[2]);
+   break;
+ }
+}
+// *************************************************** Quick & Dirty Hack - End
+
 
     $preg_user_vorhanden = "~\*|:|\(.*\)~Usim"; // Preg der Bestimmte Zeichen/Zeichenketten aus der Bezeichnung entfernt
 


### PR DESCRIPTION
"send" kann nicht korrekt überprüft werden,da objparams['form_name'] später gesetzt wird.

"formular" als form_name ist an dieser Stelle noch vorhanden
