### PR TITLE
Support for static class method callbacks

### DIFF
--- a/classes/action/class.xform.action_callback.inc.php
+++ b/classes/action/class.xform.action_callback.inc.php
@@ -40,7 +40,7 @@ class rex_xform_action_callback extends rex_xform_action_abstract
 
   function getDescription()
   {
-    return "action|callback|function";
+    return "action|callback|mycallback / myclass::mycallback";
   }
 
 }


### PR DESCRIPTION
Action modified to enable support for static class methods using the following syntax:

action|callback|myclass::mycallback

The old syntax is still retained.
