### PR TITLE
Classes/geocode tweaks

### DIFF
--- a/files/xform.css
+++ b/files/xform.css
@@ -59,7 +59,7 @@ ul.xform {
 /*  --------------------------------------- Allgemeines */
 .xform div.form_google_geocode .form_google_geocode_map {
   clear: both;
-  margin-left: 6px;
+  margin-left: 245px;
 }
 
 #rex-page-xform div.rex-area-content {

--- a/plugins/geo/xform/value/class.xform.google_geocode.inc.php
+++ b/plugins/geo/xform/value/class.xform.google_geocode.inc.php
@@ -17,9 +17,9 @@ class rex_xform_google_geocode extends rex_xform_abstract
 
     $label = $this->getElement(4);
 
-    $map_width  = ($this->getElement(5) != "") ? (int) $this->getElement(5) : 650;
-    $map_height = ($this->getElement(6) != "") ? (int) $this->getElement(6) : 400;
-    $zoom       = ($this->getElement(7) != "") ? (int) $this->getElement(7) : 12;
+    $map_width  = ($this->getElement(5) != "") ? (int) $this->getElement(5) : 400;
+    $map_height = ($this->getElement(6) != "") ? (int) $this->getElement(6) : 200;
+    $zoom       = ($this->getElement(7) != "") ? (int) $this->getElement(7) : 8;
 
     foreach($this->obj as $o)
     {


### PR DESCRIPTION
- größere default maße und sinnvollere positionierung im backend (ganze breite): http://awesomescreenshot.com/06544gb12 
- einstellbare zoomstufe..
- lat/lng nicht als floatval behandeln wg. komma/punkt probs je nach locale..
