### PR TITLE
Update files/xform.css

### DIFF
--- a/files/xform.css
+++ b/files/xform.css
@@ -70,7 +70,7 @@ ul.xform {
 .xform label,
 .xform span.as-label {
   float: left;
-  width: 245px;
+  width: 220px;
   padding-left:6px;
 }
 .xform label.captcha {


### PR DESCRIPTION
Breite der Labels von 245 auf 220 Pixel reduziert, damit TinyMCE sich besser integriert (und nicht über den Inhaltsblock hinausläuft).
