### PR TITLE
Added class for warning messages

### DIFF
--- a/classes/basic/class.rex_xform.inc.php
+++ b/classes/basic/class.rex_xform.inc.php
@@ -398,7 +398,7 @@ class rex_xform
         $warningListOut = '';
         if ($hasWarningMessages) {
           foreach ($this->objparams['warning_messages'] as $k => $v) {
-            $warningListOut .= '<li>' . rex_translate($v, null, false) . '</li>';
+            $warningListOut .= '<li class="el_'.$k.'">' . rex_translate($v, null, false) . '</li>';
           }
         }
         if ($this->objparams['unique_error'] != '') {


### PR DESCRIPTION
This allows to link the errors to the input fields they belong to.
So -with a little bit Javascript - you can generate neat error messages.
Example: http://helferverein-thw.de/foerderung/spendenquittung.html
(just click "Weiter" without typing anything)
