### PR TITLE
Fix: $mail->Sender

### DIFF
--- a/classes/action/class.xform.action_email.inc.php
+++ b/classes/action/class.xform.action_email.inc.php
@@ -27,6 +27,7 @@ class rex_xform_action_email extends rex_xform_action_abstract
     $mail->WordWrap = 80;
     $mail->FromName = $mail_from;
     $mail->From = $mail_from;
+    $mail->Sender = $mail_from;
     $mail->Subject = $mail_subject;
     $mail->Body = nl2br($mail_body);
     $mail->AltBody = strip_tags($mail_body);


### PR DESCRIPTION
$mail->Sender muss gesetzt sein, weil sonst phpmailer die -oi -f Parameter nicht gesetzt werden. Siehe class.phpmailer.php Zeile 651.
