### PR TITLE
Update class.xform.validate_email.inc.php

### DIFF
--- a/classes/validate/class.xform.validate_email.inc.php
+++ b/classes/validate/class.xform.validate_email.inc.php
@@ -14,7 +14,7 @@ class rex_xform_validate_email extends rex_xform_validate_abstract
     if ($this->params['send'] == '1')
       foreach ($this->obj_array as $Object) {
         if ($Object->getValue()) {
-          if ( !preg_match("#^[\w.+-]{2,}\@[\w.-]{2,}\.[a-z]{2,6}$#", $Object->getValue()) ) {
+          if ( !preg_match("/^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,3})$/", $Object->getValue()) ) {
             $this->params['warning'][$Object->getId()] = $this->params['error_class'];
             $this->params['warning_messages'][$Object->getId()] = $this->getElement(3);
           }


### PR DESCRIPTION
die E-Mail mit Doppelpunkt werden akzeptiert. Ich habe die Regulär Ausdrück geändert für /^[_a-z0-9-]+(.[_a-z0-9-]+)_@[a-z0-9-]+(.[a-z0-9-]+)_(.[a-z]{2,3})$/
