### PR TITLE
PHP-Variablen an xForm übergeben "LIGHT"

### DIFF
--- a/plugins/setup/module/module_out.inc
+++ b/plugins/setup/module/module_out.inc
@@ -14,7 +14,6 @@ $xform = new rex_xform;
 if ("REX_VALUE[7]" == 1) { $xform->setDebug(TRUE); }
 $form_data = 'REX_VALUE[3]';
 $form_data = trim(str_replace("<br />","",rex_xform::unhtmlentities($form_data)));
-$xform->setFormData($form_data);
 
 if (preg_match_all('/{{{([^}]*)}}}/', $form_data, $matches)) {
 	foreach ($matches[1] as $match) {
@@ -22,6 +21,8 @@ if (preg_match_all('/{{{([^}]*)}}}/', $form_data, $matches)) {
 	}	
 }
 
+
+$xform->setFormData($form_data);
 $xform->setRedaxoVars(REX_ARTICLE_ID,REX_CLANG_ID); 
 
 ?>REX_PHP_VALUE[9]<?php


### PR DESCRIPTION
Fallbeispiel

Das Array $form_vars[] wird vor Aufruf des Demo-Moduls mit einem key=>value-Paar befüllt, z.B.
$form_vars['vorschlag'] = "Schnitzel mit Pommes";

im xForm-Modul wird der Key in geschweiften Klammern anstelle des Value-Werts notiert:
hidden|speise|{{{vorschlag}}}||[no_db]

Wert wird dann vor der Ausgabe ersetzt.

Code selbst ist getestet, aber nicht mit allen Fällen, die xForm abdecken könnte. Ggf. könnte der Code auch an anderer Stelle Verwendung finden als nur im Demo-Modul.

Doku müsste entsprechend angepasst werden.
