### PR TITLE
HTML-Attribute für die value-Felder

### DIFF
--- a/classes/basic/class.xform.base.abstract.inc.php
+++ b/classes/basic/class.xform.base.abstract.inc.php
@@ -18,9 +18,9 @@ abstract class rex_xform_base_abstract
         $this->params = &$params;
         $offset = 0;
         foreach ($elements as $key => $value) {
-            if($value[0] == '#')
+            if($value[0] == '#' AND strpos($value, ':'))
             {
-                list($key, $value) = array_merge(explode(':', substr($value, 1), 2), array(''));
+                list($key, $value) = explode(':', substr($value, 1), 2);
                 $offset++;
             }
 


### PR DESCRIPTION
Mit diesem Code kann man z. B. im XForm-Formularbuilder spezielle Attribute zu den value-Klassen hinzufügen.
Die Attribute müssen als Marker mit einem Rautezeichen # beginnen, gefolgt von einem Doppelpunkt : und dem Wert des Attributs. Der Attributname darf keinen Doppelpunkt enthalten.

Bsp.:
`text|vorname|Vorname|#placeholder:Vorname`
ergibt:
`<input type="text" ... placeholder="Vorname" ... />`

Das eingefügte Attribut erhöht den Element-Index nicht.
D. h. man kann diese Attribute überall einschieben. Möglich wären z. B. auch:
`text|#placeholder:Vorname|vorname|Vorname`
`text|vorname|#placeholder:Vorname|Vorname`

Wichtig ist nur, dass der Typ (im Beispiel "text") an erster Stelle steht.
