### PR TITLE
Put query FIND_IN_SET into backticks

### DIFF
--- a/plugins/manager/classes/basic/class.rex_xform_manager.inc.php
+++ b/plugins/manager/classes/basic/class.rex_xform_manager.inc.php
@@ -762,7 +762,7 @@ class rex_xform_manager
                     $id = $params['list']->getValue('id');
                     $c = rex_sql::factory();
                     // $c->debugsql = 1;
-                    $c->setQuery('select count(id) as counter from ' . $params['params']['table'] . ' where FIND_IN_SET(' . $id . ', ' . $params['params']['field'] . ');');
+                    $c->setQuery('select count(id) as counter from ' . $params['params']['table'] . ' where FIND_IN_SET(' . $id . ', `' . $params['params']['field'] . '`);');
                     return $c->getValue('counter');
                 }
                 $gr = rex_sql::factory();


### PR DESCRIPTION
Dadurch verhindert man Fehlermeldungen, wenn z.B. Felder mit Reserved-Names (z.B. in meinem Fall "usage") nutzt

Ich hatte folgende Fehlermeldung dadurch. Nach meinen Fix, keine Fehlermeldung mehr und die korrekte Anzeige der relation: 

```
 Warning: mysql_result() expects parameter 1 to be resource, boolean given in /redaxo/include/classes/class.rex_sql.inc.php on line 309
```
