### PR TITLE
be_relation-Feld sortierbar machen

### DIFF
--- a/plugins/manager/classes/value/class.xform.be_manager_relation.inc.php
+++ b/plugins/manager/classes/value/class.xform.be_manager_relation.inc.php
@@ -220,18 +220,18 @@ class rex_xform_be_manager_relation extends rex_xform_abstract
         $sql = rex_sql::factory();
         $sql->debugsql = $this->params['debug'];
         $relationTablePreEditValues = $this->getRelationTableValues();
-        foreach ($values as $value) {
-            if (!isset($relationTablePreEditValues[$value])) {
+		
+		$sql->flushValues();
+        $sql->setTable($relationTable);
+        $sql->setWhere('`' . $sql->escape($relationTableField['source']) . '`=' . $source_id . ' AND `' . $sql->escape($relationTableField['target']) . '`');
+        $sql->delete();
+		
+        foreach (array_reverse($values) as $value) {
                 $sql->setTable($relationTable);
                 $sql->setValue($relationTableField['source'], $source_id);
                 $sql->setValue($relationTableField['target'], $value);
                 $sql->insert();
-            }
         }
-        $sql->flushValues();
-        $sql->setTable($relationTable);
-        $sql->setWhere('`' . $sql->escape($relationTableField['source']) . '`=' . $source_id . ' AND `' . $sql->escape($relationTableField['target']) . '` NOT IN (' . implode(',', $values) . ')');
-        $sql->delete();
 
     }
 


### PR DESCRIPTION
Problem:
http://www.redaxo.org/de/forum/addons-f30/xform-be-manager-relation-feld-mit-relationstab-sortieren-t20942.html

Tipp von Ingo:
http://www.redaxo.org/de/forum/addons-f30/email-templates-der-xform-mit-php-t18989.html#p117838

Änderungen:
1. Das Löschen der aller(!) alten Einträge wird zuerst ausgeführt, statt wie bisher nur die Einträge, die entfernt werden sollten.
2. Alle Einträge aus dem $values-Array werden wieder in die Tabelle hinzugefügt. 
3. array_reverse($values) ist dabei notwendig, weil sie sonst in umgekehrter Reihenfolge hinzugefügt werden.

Getestet ist es, allerdings weiß ich nicht, ob die Änderung möglicherweise an anderer Stelle negative Auswirkungen haben könnte - bisher ist mir da nichts aufgefallen.
